### PR TITLE
Cache rust build files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Add Android target to Rust
-        run: rustup target add ${{ matrix.rust-target }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: ${{ matrix.rust-target }}
 
-      - name: Update Rust
-        run: rustup update
+      - name: Cache Cargo output
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-ndk
         run: cargo install cargo-ndk

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,11 @@ jobs:
           targets: aarch64-linux-android
           components: rustfmt, clippy
 
+      - name: Cache Cargo output
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
Kinda wish we didn't have to build cargo-ndk from scratch every time too, but they aren't supported by https://github.com/taiki-e/install-action and don't have github release assets to be able to `cargo binstall`