### PR TITLE
ci: Bump the `get-current-time` GitHub Action to a version that uses Node.js 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
               name: ruffle-release-apks
 
           - name: Get current date
-            uses: 1466587594/get-current-time@v2.1.1
+            uses: 1466587594/get-current-time@v2.1.2
             id: current_date
             with:
               format: YYYYMMDD


### PR DESCRIPTION
Just so we don't get that little deprecation warning about Node.js 16 when Makeing a Release.