### PR TITLE
ci: Give Clippy its own Cargo cache

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Cache Cargo output
         uses: Swatinem/rust-cache@v2
         with:
-          shared-key: aarch64-linux-android
+          shared-key: clippy
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Check formatting


### PR DESCRIPTION
So that it doesn't collide with the one for the build job.
The architecture we use as target when running Clippy is not really relevant.