### PR TITLE
Fix touch deviation caused by partial view not being full screen

### DIFF
--- a/app/src/main/java/rs/ruffle/PlayerActivity.kt
+++ b/app/src/main/java/rs/ruffle/PlayerActivity.kt
@@ -76,9 +76,9 @@ class PlayerActivity : GameActivity() {
 
     @Suppress("unused")
     // Used by Rust
-    private val locOnScreen: IntArray
+    private val locInWindow: IntArray
         get() {
-            mSurfaceView.getLocationOnScreen(loc)
+            mSurfaceView.getLocationInWindow(loc)
             return loc
         }
 

--- a/src/java.rs
+++ b/src/java.rs
@@ -18,7 +18,7 @@ pub struct JavaInterface {
     get_swf_bytes: JMethodID,
     get_swf_uri: JMethodID,
     get_trace_output: JMethodID,
-    get_loc_on_screen: JMethodID,
+    get_loc_in_window: JMethodID,
 }
 
 static JAVA_INTERFACE: OnceLock<JavaInterface> = OnceLock::new();
@@ -128,12 +128,12 @@ impl JavaInterface {
         Some(url.into())
     }
 
-    pub fn get_loc_on_screen(env: &mut JNIEnv, this: &JObject) -> (i32, i32) {
+    pub fn get_loc_in_window(env: &mut JNIEnv, this: &JObject) -> (i32, i32) {
         let result = unsafe {
-            env.call_method_unchecked(this, Self::get().get_loc_on_screen, ReturnType::Array, &[])
+            env.call_method_unchecked(this, Self::get().get_loc_in_window, ReturnType::Array, &[])
         };
         let object = result
-            .expect("getLocOnScreen() must never throw")
+            .expect("getLocInWindow() must never throw")
             .l()
             .unwrap();
         let arr = JIntArray::from(object);
@@ -172,9 +172,9 @@ impl JavaInterface {
                 get_trace_output: env
                     .get_method_id(class, "getTraceOutput", "()Ljava/lang/String;")
                     .expect("getTraceOutput must exist"),
-                get_loc_on_screen: env
-                    .get_method_id(class, "getLocOnScreen", "()[I")
-                    .expect("getLocOnScreen must exist"),
+                get_loc_in_window: env
+                    .get_method_id(class, "getLocInWindow", "()[I")
+                    .expect("getLocInWindow must exist"),
             })
             .unwrap_or_else(|_| panic!("Init cannot be called more than once!"))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,7 @@ fn run(app: AndroidApp) {
                                         let window = native_window.as_ref().unwrap();
                                         let pointer = event.pointer_index();
                                         let pointer = event.pointer_at_index(pointer);
-                                        let coords: (i32, i32) = get_loc_on_screen();
+                                        let coords: (i32, i32) = get_loc_in_window();
                                         let mut x = pointer.x() as f64 - coords.0 as f64;
                                         let mut y = pointer.y() as f64 - coords.1 as f64;
                                         let view_size = get_view_size().unwrap();
@@ -549,14 +549,14 @@ pub unsafe extern "C" fn Java_rs_ruffle_PlayerActivity_nativeInit(mut env: JNIEn
     JavaInterface::init(&mut env, &class)
 }
 
-fn get_loc_on_screen() -> (i32, i32) {
+fn get_loc_in_window() -> (i32, i32) {
     let (jvm, activity) = get_jvm().unwrap();
     let mut env = jvm.attach_current_thread().unwrap();
 
     // no worky :(
     //ndk_glue::native_activity().show_soft_input(true);
 
-    JavaInterface::get_loc_on_screen(&mut env, &activity)
+    JavaInterface::get_loc_in_window(&mut env, &activity)
 }
 
 fn get_view_size() -> Result<(i32, i32), Box<dyn std::error::Error>> {


### PR DESCRIPTION
On some Android 9 devices, it was found that there was a touch deviation when the game view was not in full-screen mode. The reason for this was the difference between getX() and getRawY(), and the use of locInWindow() to calculate relative coordinates.
Look at the picture
![view](https://github.com/ruffle-rs/ruffle-android/assets/54072623/0501e580-371c-4dc4-b6a0-2ded47c6380a)
