### PR TITLE
ci: Switch to the new Gradle wrapper validation action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      - uses: gradle/wrapper-validation-action@v3
+      - uses: gradle/actions/wrapper-validation@v3
         name: Validate Gradle Wrapper
 
       - name: Check ktlint


### PR DESCRIPTION
As per: https://github.com/gradle/wrapper-validation-action/blob/460a3ca/README.md