### PR TITLE
Hold back the Android testing workflow on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
   android-tests:
     name: Android Tests
     needs: build-native-libs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         api-level: [26, 34]


### PR DESCRIPTION
See:

https://github.com/ruffle-rs/ruffle-android/actions/runs/11109743588/job/30866815983#step:8:76

https://github.com/ReactiveCircus/android-emulator-runner/issues/400
https://github.com/ReactiveCircus/android-emulator-runner/pull/327