### PR TITLE
Hold back the Android testing workflow on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
   android-tests:
     name: Android Tests
     needs: build-native-libs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         api-level: [26, 34]


### PR DESCRIPTION
This is https://github.com/ruffle-rs/ruffle-android/pull/270, but targeting the right branch...