### PR TITLE
Switch GHA workflows back to ubuntu-latest (currently 24.04)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
   android-tests:
     name: Android Tests
     needs: build-native-libs
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         api-level: [26, 34]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
     make-release:
         name: Make Release
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-latest
 
         steps:
           - uses: actions/checkout@v4


### PR DESCRIPTION
Reverts https://github.com/ruffle-rs/ruffle-android/pull/271.
Apparently it should work now... ?
https://github.com/ReactiveCircus/android-emulator-runner/issues/400