### PR TITLE
Bump target API to 35, clean up intent-filter data in manifest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [26, 34]
+        api-level: [26, 35]
 
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
 ### Requirements
 Before you can build the app from source, you'll need to grab a few things.
 
-- Install Android Studio with at least the Platform SDK (e.g. version 34) and the NDK Tools (e.g. version 26).
+- Install Android Studio with at least the Platform SDK (e.g. version 35) and the NDK Tools (e.g. version 26).
 - Install jdk 17 (potentially included with Android Studio)
 - Install [rust](https://rustup.rs/)
 - `cargo install cargo-ndk`

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,12 +14,12 @@ plugins {
 
 android {
     namespace = "rs.ruffle"
-    compileSdk = 34
+    compileSdk = 35
 
     defaultConfig {
         applicationId = "rs.ruffle"
         minSdk = 26
-        targetSdk = 34
+        targetSdk = 35
         versionCode = 1
         versionName = "1.0"
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,8 +54,8 @@
 
                 <data android:mimeType="application/x-shockwave-flash"/>
 
-                <data android:pathSuffix="swf" />
-                <data android:pathPattern="*.swf" />
+                <data android:host="*" />
+                <data android:pathPattern=".*.swf" />
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
Extracted from https://github.com/ruffle-rs/ruffle-android/pull/316, will unblock https://github.com/ruffle-rs/ruffle-android/pull/330.

These caveats still apply:
 - https://github.com/ruffle-rs/ruffle-android/pull/316#issuecomment-2501646021
 - https://github.com/ruffle-rs/ruffle-android/pull/316#issuecomment-2501650401