### PR TITLE
Remove `DependencyInfoBlock`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -105,6 +105,12 @@ android {
             }
         }
     }
+    dependenciesInfo {
+        // Disables dependency metadata when building APKs.
+        includeInApk = false
+        // Disables dependency metadata when building Android App Bundles.
+        includeInBundle = false
+    }
 }
 
 androidComponents {


### PR DESCRIPTION
* https://github.com/ruffle-rs/ruffle-android/pull/460#issuecomment-2985738761

I find that there is a `DependencyInfoBlock` in your APK.

It's a [Signing block](https://source.android.com/docs/security/features/apksigning/v2#apk-signing-block) added by AGP and encrypted with the Google public key so it can't be read by anyone else except Google. You can read more about it [here](https://gitlab.com/fdroid/admin/-/issues/367) and [here](https://gitlab.com/fdroid/fdroidserver/-/issues/1056).

While this was added a while ago, F-Droid were only enforcing it for new apps, and recently they started scanning updates too.

I have disabled it with the following code.

```
android {
    dependenciesInfo {
        // Disables dependency metadata when building APKs.
        includeInApk = false
        // Disables dependency metadata when building Android App Bundles.
        includeInBundle = false
    }
}
```

I'll need a new release with this fix.

https://gitlab.com/fdroid/fdroiddata/-/issues/3330#note_2189915200