### PR TITLE
Downgrade Android Gradle Plugin (agp) to 8.11.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.0"
+agp = "8.11.1"
 kotlin = "2.2.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"


### PR DESCRIPTION
So the F-Droid build server can still build the app.
See: https://issuetracker.google.com/issues/438515318
Fixes https://github.com/ruffle-rs/ruffle-android/issues/522.