### PR TITLE
chore: Bump Rascal to 0.3.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,12 +293,6 @@ checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitstream-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6099cdc01846bc367c4e7dd630dc5966dccf36b652fae7a74e17b640411a91b2"
-
-[[package]]
-name = "bitstream-io"
 version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
@@ -337,7 +331,7 @@ dependencies = [
  "quote",
  "rascal",
  "regex",
- "swf 0.3.0",
+ "swf 0.3.0 (git+https://github.com/ruffle-rs/ruffle.git?branch=master)",
  "walkdir",
 ]
 
@@ -2072,7 +2066,7 @@ name = "nellymoser-rs"
 version = "0.1.2"
 source = "git+https://github.com/ruffle-rs/nellymoser?rev=073eb48d907201f46dea0c8feb4e8d9a1d92208c#073eb48d907201f46dea0c8feb4e8d9a1d92208c"
 dependencies = [
- "bitstream-io 4.10.0",
+ "bitstream-io",
  "once_cell",
  "rustdct",
 ]
@@ -2634,16 +2628,14 @@ checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rascal"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126759e1b358dd7c999f3d6b83a839b99cb383bf6bbd1f9e4e8f6b810df85485"
+checksum = "ba78442f12cbfa28edad7c0f1e02c370cb2d985fb7de98962e2c6893e6bd4d85"
 dependencies = [
  "annotate-snippets",
- "byteorder",
  "indexmap",
- "log",
  "serde",
- "swf 0.2.2",
+ "swf 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winnow",
 ]
 
@@ -2820,7 +2812,7 @@ dependencies = [
  "regress",
  "ruffle_macros",
  "ruffle_wstr",
- "swf 0.3.0",
+ "swf 0.3.0 (git+https://github.com/ruffle-rs/ruffle.git?branch=master)",
  "thiserror 2.0.18",
  "tracing",
  "url",
@@ -2833,7 +2825,7 @@ source = "git+https://github.com/ruffle-rs/ruffle.git?branch=master#6890c618daab
 dependencies = [
  "async-channel",
  "bitflags 2.13.1",
- "bitstream-io 4.10.0",
+ "bitstream-io",
  "build_playerglobal",
  "bytemuck",
  "byteorder",
@@ -2878,7 +2870,7 @@ dependencies = [
  "serde_json",
  "slotmap",
  "smallvec",
- "swf 0.3.0",
+ "swf 0.3.0 (git+https://github.com/ruffle-rs/ruffle.git?branch=master)",
  "symphonia",
  "thiserror 2.0.18",
  "tracing",
@@ -2944,7 +2936,7 @@ dependencies = [
  "png",
  "ruffle_wstr",
  "smallvec",
- "swf 0.3.0",
+ "swf 0.3.0 (git+https://github.com/ruffle-rs/ruffle.git?branch=master)",
  "thiserror 2.0.18",
  "tracing",
  "wgpu",
@@ -2967,7 +2959,7 @@ dependencies = [
  "naga-pixelbender",
  "ruffle_render",
  "smallvec",
- "swf 0.3.0",
+ "swf 0.3.0 (git+https://github.com/ruffle-rs/ruffle.git?branch=master)",
  "tracing",
  "web-sys",
  "wgpu",
@@ -2981,7 +2973,7 @@ source = "git+https://github.com/ruffle-rs/ruffle.git?branch=master#6890c618daab
 dependencies = [
  "ruffle_render",
  "slotmap",
- "swf 0.3.0",
+ "swf 0.3.0 (git+https://github.com/ruffle-rs/ruffle.git?branch=master)",
  "thiserror 2.0.18",
 ]
 
@@ -3000,7 +2992,7 @@ dependencies = [
  "ruffle_render",
  "ruffle_video",
  "slotmap",
- "swf 0.3.0",
+ "swf 0.3.0 (git+https://github.com/ruffle-rs/ruffle.git?branch=master)",
  "thiserror 2.0.18",
 ]
 
@@ -3301,13 +3293,12 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swf"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "802bff556571f7e5c6e347d5f147f91d1e5976bb43fb312437f04676707bbe4f"
+checksum = "b1840721af70281567fdcbbf16e81b297db77d695c7b4a64860b18da15bb401a"
 dependencies = [
  "bitflags 2.13.1",
- "bitstream-io 2.6.0",
- "byteorder",
+ "bitstream-io",
  "encoding_rs",
  "enum-map",
  "flate2",
@@ -3324,7 +3315,7 @@ version = "0.3.0"
 source = "git+https://github.com/ruffle-rs/ruffle.git?branch=master#6890c618daab31533437e8c5cd5a5cb6e1ae5d6c"
 dependencies = [
  "bitflags 2.13.1",
- "bitstream-io 4.10.0",
+ "bitstream-io",
  "encoding_rs",
  "enum-map",
  "flate2",


### PR DESCRIPTION
Thereby deduplicating `bitstream-io`.